### PR TITLE
Java 6 support and fix for UTF-8 under OS X

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,4 +7,5 @@
                  [instaparse "1.0.1"]
                  [org.clojure/core.match "0.2.0-alpha12"]
                  [org.clojure/core.logic "0.8.3"]]
+  :jvm-opts ["-Dfile.encoding=utf-8"]
   :main bodol.repl)

--- a/src/bodol/parser.clj
+++ b/src/bodol/parser.clj
@@ -22,7 +22,7 @@ NUMBER = NEGATIVE* (FRACTION | DECIMAL | INTEGER)
 <DECIMAL> = INTEGER '.' INTEGER
 <INTEGER> = #'\\p{Digit}+'
 STRING = '\\\"' #'([^\"\\\\]|\\\\.)*' '\\\"'
-SYMBOL = #'[\\p{IsAlphabetic}_$&/=+~:<>|§?*-][\\p{IsAlphabetic}\\{Digit}_$&/=+~.:<>|§?*-]*'
+SYMBOL = #'[\\pL_$&/=+~:<>|§?*-][\\pL\\{Digit}_$&/=+~.:<>|§?*-]*'
 <SPACE> = <(' ' | '\t' | '\n' | ',')+>
 "))
 


### PR DESCRIPTION
Hi @bodil, I'm really excited about this language. Shen-like without a crazy license!

I wanted to quickly play with it but ran into two problems under my environment.

---
## Specify file.encoding as UTF-8 in Lein project

Under OS X, I was presented with the following:

```
BODOL version 0.0.0
You are in a maze of twisty little passages, all alike.
??
```

I then tried to input:

```
(ƒ triplet a b c -> (list a b c))
```

It looked right in the terminal but didn't parse correct. Specifying the Java file encoding to be UTF-8 fixed everything.

---
## Use Java 6 compatible symbol regex pattern

The `isAlphabetic` method only appears in Java 7. The Letter Unicode category (L) should hopefully be enough. The only case I can think that's left out is the 'Number, Letter' category which has things like Roman Numerals. I think that's fine to leave out.
